### PR TITLE
feat(serializer): handle null and array cases for performance

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -13,6 +13,9 @@ function getSerializerFromObject(object) {
     if (object &&  object.__name__ && serializers[object.__name__]) {
         return serializers[object.__name__];
     }
+    if (Array.isArray(object)) {
+        return null;
+    }
     for (var k in serializers) {
         if (serializers[k].class && object instanceof serializers[k].class) {
             return serializers[k];
@@ -23,7 +26,7 @@ function getSerializerFromObject(object) {
 
 function objectSerializer(object) {
     return cloneDeepWith(object, function(value) {
-        if (typeof value != "object") {
+        if (typeof value != "object" || value === null) {
             return;
         }
         var serializer = getSerializerFromObject(value);


### PR DESCRIPTION
To prevent the for-loop on defined serializers, we can handle null and Array cases with early return